### PR TITLE
TransHistory misspelling

### DIFF
--- a/btceapi.py
+++ b/btceapi.py
@@ -64,7 +64,7 @@ class api:
    "order"	: torder,
    "since"	: tsince,
    "end"	: tend}
-  return self.__api__call('TransHistory', params)
+  return self.__api_call('TransHistory', params)
  
  def TradeHistory(self, tfrom, tcount, tfrom_id, tend_id, torder, tsince, tend, tpair):
   params = {


### PR DESCRIPTION
changed return to self.__api_call('TransHistory', params)
from self.__api__call('TransHistory', params)
